### PR TITLE
Reformat Changes as perl CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,7 +11,7 @@ Revision history for Perl extension Sub::Retry
 
     - Do not sleep in last time
 
-0.04 2011-06-04
+0.04 2011-07-04
 
     - fixed typo in docs(xaicron)
 


### PR DESCRIPTION
Hi,

I've reformatted your Changes file according to the spec in `CPAN::Changes::Spec`. I looked up missing dates at [BackPAN](http://backpan.perl.org/authors/id/T/TO/TOKUHIROM/).

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org/), which is where I saw your module listed :-)

Cheers,
Sergey
